### PR TITLE
Add Dana wallet to wallets doc

### DIFF
--- a/content/docs/wallets.md
+++ b/content/docs/wallets.md
@@ -19,6 +19,7 @@ I'll do my best to keep this page up to date, but if you see something that need
 | [Cake Wallet](https://cakewallet.com)[^2]  | [cake-tech/cake_wallet](https://github.com/cake-tech/cake_wallet) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}}      |
 | [BlueWallet](https://bluewallet.io/)       | [bluewallet/bluewallet](https://github.com/bluewallet/bluewallet) | {{< icon "check-green" >}} | {{< icon "x-red" >}}       | {{< icon "x-red" >}}            |
 | [Silentium](https://app.silentium.dev)[^2] | [louisinger/silentium](https://github.com/louisinger/silentium)   | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}}      |
+| [Dana Wallet](https://silentpayments.dev)  | [cygnet3/danawallet](https://github.com/cygnet3/danawallet)       | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}}      |
 
 [^1]: "Privacy preserving scanning" here denotes an architecture where no output information is revealed to the back-end server. While this is the only possible back-end approach for now, it's very likely we will see future approaches that give the view key over to a back-end server to allow background sync, while sacrificing privacy of Silent Payments outputs to that third-party server. This field is a way that we can denote that in the future as-necessary.
 [^2]: Silentium is a proof-of-concept and should be used with caution! From the developer:


### PR DESCRIPTION
Dana wallet is a new silent payment-only wallet that has been in the works for some time now. It is still in an alpha release, but it recently had its [first public release](https://github.com/cygnet3/danawallet/releases/tag/v0.1.0-alpha), now would be a good time to add it to the list.