### PR TITLE
add shakespay

### DIFF
--- a/content/docs/developers.md
+++ b/content/docs/developers.md
@@ -32,6 +32,8 @@ For the developers among you, this page is a simple page to point you in the rig
 - [Bitshala-Incubator/silent-pay](https://github.com/Bitshala-Incubator/silent-pay)
   - "A bitcoin wallet library that supports silent payments out of the box."
   > This library is currently in an experimental stage and should be used with caution. It has not undergone extensive testing and may contain bugs, vulnerabilities, or unexpected behavior. Mainnet use is strictly NOT recommended.
+- [shakesco/silent](https://github.com/shakesco/shakesco-silent)
+  - A JavaScript SDK offering comprehensive support for silent payments, including sending, receiving, and scanning functionality. Designed for Shakespay wallet or any other wallet
 
 ## Scanning back-ends
 

--- a/content/docs/wallets.md
+++ b/content/docs/wallets.md
@@ -21,7 +21,7 @@ I'll do my best to keep this page up to date, but if you see something that need
 | [Silentium](https://app.silentium.dev)[^2] | [louisinger/silentium](https://github.com/louisinger/silentium)   | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}}      |
 | [Dana Wallet](https://silentpayments.dev)  | [cygnet3/danawallet](https://github.com/cygnet3/danawallet)       | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}}      |
 | [BitBox](https://bitbox.swiss/) | [BitBoxSwiss/bitbox-wallet-app](https://github.com/BitBoxSwiss/bitbox-wallet-app) | {{< icon "check-green" >}} | {{< icon "x-red" >}} | {{< icon "x-red" >}} |
-| [Shakespay Wallet](https://shakesco.com)  | [shakesco/silent](https://github.com/shakesco/shakesco-silent)       | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}}      |
+| [Shakesco Wallet](https://shakesco.com)  | [shakesco/silent](https://github.com/shakesco/shakesco-silent)       | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}}      |
 
 [^1]: "Privacy preserving scanning" here denotes an architecture where no output information is revealed to the back-end server. While this is the only possible back-end approach for now, it's very likely we will see future approaches that give the view key over to a back-end server to allow background sync, while sacrificing privacy of Silent Payments outputs to that third-party server. This field is a way that we can denote that in the future as-necessary.
 [^2]: Silentium is a proof-of-concept and should be used with caution! From the developer:

--- a/content/docs/wallets.md
+++ b/content/docs/wallets.md
@@ -20,6 +20,7 @@ I'll do my best to keep this page up to date, but if you see something that need
 | [BlueWallet](https://bluewallet.io/)       | [bluewallet/bluewallet](https://github.com/bluewallet/bluewallet) | {{< icon "check-green" >}} | {{< icon "x-red" >}}       | {{< icon "x-red" >}}            |
 | [Silentium](https://app.silentium.dev)[^2] | [louisinger/silentium](https://github.com/louisinger/silentium)   | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}}      |
 | [Dana Wallet](https://silentpayments.dev)  | [cygnet3/danawallet](https://github.com/cygnet3/danawallet)       | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}}      |
+| [Shakespay Wallet](https://shakesco.com)  | [shakesco/silent](https://github.com/shakesco/shakesco-silent)       | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}}      |
 
 [^1]: "Privacy preserving scanning" here denotes an architecture where no output information is revealed to the back-end server. While this is the only possible back-end approach for now, it's very likely we will see future approaches that give the view key over to a back-end server to allow background sync, while sacrificing privacy of Silent Payments outputs to that third-party server. This field is a way that we can denote that in the future as-necessary.
 [^2]: Silentium is a proof-of-concept and should be used with caution! From the developer:


### PR DESCRIPTION
Hey Seth,

Shakespay just integrated silent payments, both sending and receiving. Everyone can also spend the silent payments received.

Scanning is a bit shit, but i am working on it.

Shakespay packages: [SDK](https://github.com/shakesco/shakesco-silent) or [Dart](https://github.com/shakesco/bitcoin_base) or [docs](https://docs.shakesco.com/docs/silent/integration/)

Shakespay wallet is available on [IOS ](https://apps.apple.com/us/app/shakespay-bitcoin-ethereum/id6478241603)and [android](https://play.google.com/store/apps/details?id=com.shakesco.shakespay2) for anyone to send and receive Bitcoin silent payments.