### PR TITLE
Update hugo.yaml to add discord link

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -42,6 +42,11 @@ menu:
       url: "https://github.com/sethforprivacy/silentpaymentsxyz"
       params:
         icon: github
+    - name: Discord
+      weight: 4
+      url: "https://discord.gg/BExA2YGsgY"
+      params:
+        icon: discord
 
   sidebar:
     - identifier: more


### PR DESCRIPTION
We have a silent payments discord server.

This PR adds invite link to the same on the header.

Tested on local (see below):

![oefkjd](https://github.com/user-attachments/assets/1b9ca5d3-f521-440c-ab53-098e2ccf9469)
