### PR TITLE
Add zine links to sidebar

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -62,6 +62,14 @@ menu:
       name: "Silent Payments BIP ↗"
       url: "https://bips.dev/352/"
       weight: 1
+    - identifier: zine
+      name: "Satsie's zine ↗"
+      url: "https://satsie.dev/zines/silentpayments.html"
+      weight: 3
+    - identifier: ux zine
+      name: "Yashraj's UX zine ↗"
+      url: "https://satsie.dev/zines/collabs/yashrajsilentpaymentsux.html"
+      weight: 4
 
 params:
   description: A simple site detailing Silent Payments, their value, their usage, and their current wallet support.


### PR DESCRIPTION
These silent payments zines are hosted on satsie's website.

I've added them to the sidebar.

![vfd](https://github.com/user-attachments/assets/f2f03e34-b633-4131-a438-7cfc8a83e06c)
