### PR TITLE
Add Agora to software wallets (BIP-352 send + receive, privacy-preserving scanning)

### DIFF
--- a/content/docs/wallets.md
+++ b/content/docs/wallets.md
@@ -18,6 +18,7 @@ I'll do my best to keep this page up to date, but if you see something that need
 
 | Wallet | Github | Sending | Receiving | Privacy-preserving scanning[^1] | BIP375[^3] | BIP376[^4] |
 | ------ | ------ | :-----: | :-------: | :-----------------------------: | :--------: | :--------: |
+| [Agora](https://agora.spot) | [soapbox-pub/agora](https://gitlab.com/soapbox-pub/agora) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | - |
 | [BitBox](https://bitbox.swiss/) | [BitBoxSwiss/bitbox-wallet-app](https://github.com/BitBoxSwiss/bitbox-wallet-app) | {{< icon "check-green" >}} | {{< icon "x-red" >}} | - | - | - |
 | [Bitcoin Core](https://bitcoin.org/en/bitcoin-core/) | [bitcoin/bitcoin](https://github.com/bitcoin/bitcoin/pull/32966) | {{< icon "wip" >}} | {{< icon "wip" >}} | {{< icon "check-green" >}} | - | - |
 | [BlindBit Desktop](https://github.com/setavenger/blindbit-desktop/releases) | [setavenger/blindbit-desktop](https://github.com/setavenger/blindbit-desktop/) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | - |


### PR DESCRIPTION
Adds **Agora** to the Software wallets table.

Agora is an open-source, non-custodial Bitcoin donation/crowdfunding platform with a built-in HD wallet supporting BIP-352:

- **Sending** ✅ — pays any `sp1…` address directly
- **Receiving** ✅ — campaigns and wallet accept silent payments
- **Privacy-preserving scanning** ✅ — BlindBit Oracle backend serves only public per-tx tweak data; ECDH completed locally, scan key never leaves the device
- BIP-375/376: N/A (software wallet, not a PSBT hardware signer)
- Standard BIP-86 + BIP-352 derivation (seed portable to Sparrow/Electrum/etc.)

Repo is on GitLab: https://gitlab.com/soapbox-pub/agora (noting since the table currently links GitHub repos).

Relates to #46 — happy to move it to a dedicated section for SP-using applications if you'd prefer that over the wallets table.