### PR TITLE
Add live PR preview deployments via GitHub Pages

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,56 @@
+name: Build PR preview
+
+# Stage 1 of the PR preview pipeline.
+#
+# Runs on the (untrusted) PR head with NO secrets and read-only access, so it is
+# safe for pull requests opened from forks. It only builds the Hugo site and
+# uploads it as an artifact. The trusted "Deploy PR preview" workflow picks that
+# artifact up afterwards via workflow_run and publishes it to GitHub Pages.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-build-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0          # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: 'latest'
+          extended: true
+
+      - name: Build site with preview baseURL
+        run: |
+          hugo \
+            --destination ./public \
+            --baseURL "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}/"
+
+      - name: Record PR number for the deploy stage
+        run: echo "${{ github.event.number }}" > pr-number.txt
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-preview
+          path: |
+            public/
+            pr-number.txt
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,72 @@
+name: Cleanup PR preview
+
+# Stage 3 of the PR preview pipeline.
+#
+# Removes a PR's preview from gh-pages when the PR is closed or merged.
+#
+# Uses pull_request_target so it gets a write token even for fork PRs. This is
+# safe here because it never checks out or runs the PR's code -- it only deletes
+# a directory on the gh-pages branch keyed by the (trusted) PR number.
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  contents: write        # push to gh-pages
+  pull-requests: write   # update the preview comment
+
+concurrency:
+  group: preview-gh-pages
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Remove preview from gh-pages
+        env:
+          PR: ${{ github.event.number }}
+        run: |
+          set -euo pipefail
+          if ! git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            echo "No gh-pages branch; nothing to clean up."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages
+          git checkout -B gh-pages origin/gh-pages
+
+          target="pr-preview/pr-${PR}"
+          if [ ! -d "$target" ]; then
+            echo "No preview directory for PR #${PR}; nothing to remove."
+            exit 0
+          fi
+
+          git rm -rf "$target"
+          git commit -m "Remove preview for PR #${PR}"
+
+          for attempt in 1 2 3; do
+            if git push origin gh-pages; then
+              exit 0
+            fi
+            echo "Push failed (attempt $attempt), rebasing on latest gh-pages..."
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+          done
+          echo "Failed to push gh-pages after retries." >&2
+          exit 1
+
+      - name: Update the preview comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ github.event.number }}
+          header: pr-preview
+          message: |
+            ### 🧹 Preview removed
+
+            The temporary preview for this PR has been torn down now that it is closed.

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,109 @@
+name: Deploy PR preview
+
+# Stage 2 of the PR preview pipeline.
+#
+# Triggered by the completion of "Build PR preview". Because workflow_run always
+# runs from the base repository's default branch, it has a trusted context with
+# write access even when the PR came from a fork. It never checks out or executes
+# the PR's code -- it only takes the already-built artifact and publishes it to
+# the gh-pages branch under pr-preview/pr-<N>/.
+
+on:
+  workflow_run:
+    workflows: ["Build PR preview"]
+    types:
+      - completed
+
+permissions:
+  contents: write        # push to gh-pages
+  pull-requests: write   # post the preview comment
+  actions: read          # download the artifact from the build run
+
+# Serialize all writes to gh-pages (deploys + cleanups) so concurrent runs
+# don't race on the same branch.
+concurrency:
+  group: preview-gh-pages
+
+jobs:
+  deploy:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download preview artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-preview
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ runner.temp }}/preview
+
+      - name: Read PR number
+        id: pr
+        run: |
+          num=$(cat "${{ runner.temp }}/preview/pr-number.txt")
+          # Guard against anything that isn't a plain integer.
+          case "$num" in
+            ''|*[!0-9]*) echo "Invalid PR number: '$num'" >&2; exit 1 ;;
+          esac
+          echo "number=$num" >> "$GITHUB_OUTPUT"
+
+      # Checkout to get an authenticated git remote we can push gh-pages with.
+      - uses: actions/checkout@v7
+
+      - name: Publish preview to gh-pages
+        env:
+          PR: ${{ steps.pr.outputs.number }}
+          SRC: ${{ runner.temp }}/preview/public
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git fetch origin gh-pages
+            git checkout -B gh-pages origin/gh-pages
+          else
+            git checkout --orphan gh-pages
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          target="pr-preview/pr-${PR}"
+          rm -rf "$target"
+          mkdir -p "$target"
+          cp -R "$SRC"/. "$target"/
+          touch .nojekyll
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
+          git commit -m "Deploy preview for PR #${PR}"
+
+          # Retry against concurrent updates to gh-pages.
+          for attempt in 1 2 3; do
+            if git push origin gh-pages; then
+              exit 0
+            fi
+            echo "Push failed (attempt $attempt), rebasing on latest gh-pages..."
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+          done
+          echo "Failed to push gh-pages after retries." >&2
+          exit 1
+
+      - name: Comment preview URL on the PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.number }}
+          header: pr-preview
+          message: |
+            ### 🔎 Live preview ready
+
+            This PR has been deployed to a temporary preview site:
+
+            **https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ steps.pr.outputs.number }}/**
+
+            The preview updates on every push and is removed when the PR is closed.


### PR DESCRIPTION
## What this does

Adds a three-stage GitHub Actions pipeline that publishes a clickable **live preview** of the rendered site for every pull request, at:

`https://sethforprivacy.github.io/silentpaymentsxyz/pr-preview/pr-<N>/`

The preview refreshes on every push and is torn down when the PR closes. A sticky comment with the URL is posted on each PR.

## Workflows

| File | Trigger | Role |
|---|---|---|
| `preview-build.yml` | `pull_request` | Builds the Hugo site on the (untrusted) PR head with a preview sub-path `baseURL`; uploads `public/` as an artifact. Read-only, no secrets — **safe for fork PRs**. |
| `preview-deploy.yml` | `workflow_run` | Trusted base-repo context with write access. Publishes the artifact to `gh-pages` under `pr-preview/pr-<N>/` and comments the URL. Never runs PR code. |
| `preview-cleanup.yml` | PR `closed` | Removes the PR's preview folder and updates the comment. |

## Why three workflows

Community wallet PRs come from forks, which get a read-only token with no secrets. The build → `workflow_run` → deploy handoff is the standard secure pattern that still gives fork PRs previews, without exposing a write-token to untrusted Hugo template execution. Writes to `gh-pages` are scoped to a single PR folder, so previews never clobber each other; a `.nojekyll` file ensures Hugo output is served verbatim.

## One-time setup after merge

These only take effect once on `master` (`workflow_run` / `pull_request_target` run from the default branch).

1. Merge this PR.
2. **Settings → Pages → Source: "Deploy from a branch" → Branch: `gh-pages` / `(root)`** (the `gh-pages` branch has been pre-created empty so this can be done immediately).
3. Open a PR — the preview URL will be posted as a comment once deploy finishes.

Does not affect production: `silentpayments.xyz` is served by the existing nginx/GHCR image. Pages only serves previews on the `github.io` host. The existing `test-site-build.yml` smoke test is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)