### PR TITLE
New wallet categorization

### DIFF
--- a/content/docs/wallets.md
+++ b/content/docs/wallets.md
@@ -24,7 +24,7 @@ Bitcoin wallets with Silent Payments support, grouped by what you can do today: 
 | ------ | ------ | :-----: | :-------: | :-----------------------------: | :--------: | :--------: |
 | [BlindBit Desktop](https://github.com/setavenger/blindbit-desktop/releases) | [setavenger/blindbit-desktop](https://github.com/setavenger/blindbit-desktop/) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | - |
 | [Cake Wallet](https://cakewallet.com) | [cake-tech/cake_wallet](https://github.com/cake-tech/cake_wallet) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | - |
-| [Dana Wallet](https://danawallet.app) | [cygnet3/dana](https://github.com/cygnet3/dana) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | - |
+| [Dana Wallet](https://danawallet.app) | [cygnet3/dana](https://github.com/cygnet3/dana) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "wip" >}} | {{< icon "wip" >}} |
 | [Sparrow Wallet](https://sparrowwallet.com/) | [sparrowwallet/sparrow](https://github.com/sparrowwallet/sparrow) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | {{< icon "check-green" >}} | {{< icon "check-green" >}} |
 
 ### Send-only
@@ -51,7 +51,8 @@ Signing devices for Silent Payment transactions (BIP375 to send, BIP376 to spend
 | ------ | ------ | :-----: | :----: | :----: |
 | [BitBox02](https://bitbox.swiss/) | [BitBoxSwiss/bitbox02-firmware](https://github.com/BitBoxSwiss/bitbox02-firmware) | {{< icon "check-green" >}} | {{< icon "x-red" >}} | {{< icon "x-red" >}} |
 | [Coldcard](https://coldcard.com/) | [Coldcard/firmware](https://github.com/Coldcard/firmware) | {{< icon "wip" >}} | {{< icon "wip" >}} | {{< icon "wip" >}} |
-| [SeedSigner](https://seedsigner.com/) | [SeedSigner/seedsigner](https://github.com/SeedSigner/seedsigner) | {{< icon "wip" >}} | {{< icon "x-red" >}} | {{< icon "x-red" >}} |
+| [Krux](https://selfcustody.github.io/krux/) | [selfcustody/krux](https://github.com/selfcustody/krux) | {{< icon "wip" >}} | {{< icon "wip" >}} | {{< icon "wip" >}} |
+| [SeedSigner](https://seedsigner.com/) | [SeedSigner/seedsigner](https://github.com/SeedSigner/seedsigner) | {{< icon "wip" >}} | {{< icon "wip" >}} | {{< icon "wip" >}} |
 
 ## Applications
 

--- a/content/docs/wallets.md
+++ b/content/docs/wallets.md
@@ -14,30 +14,60 @@ I'll do my best to keep this page up to date, but if you see something that need
   As Silent Payments are so new, please be cautious when testing new wallets with real funds!
 {{< /callout >}}
 
-## Software wallets
+## Wallets
 
-| Wallet | Github | Sending | Receiving | Privacy-preserving scanning[^1] | BIP375[^3] | BIP376[^4] |
+Bitcoin wallets with Silent Payments support, grouped by what you can do today: **send & receive**, **send-only**, and **in progress** where support is still landing.
+
+### Send & receive
+
+| Wallet | Source | Sending | Receiving | Privacy-preserving scanning[^1] | BIP375[^3] | BIP376[^4] |
 | ------ | ------ | :-----: | :-------: | :-----------------------------: | :--------: | :--------: |
-| [Agora](https://agora.spot) | [soapbox-pub/agora](https://gitlab.com/soapbox-pub/agora) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | - |
-| [BitBox](https://bitbox.swiss/) | [BitBoxSwiss/bitbox-wallet-app](https://github.com/BitBoxSwiss/bitbox-wallet-app) | {{< icon "check-green" >}} | {{< icon "x-red" >}} | - | - | - |
-| [Bitcoin Core](https://bitcoin.org/en/bitcoin-core/) | [bitcoin/bitcoin](https://github.com/bitcoin/bitcoin/pull/32966) | {{< icon "wip" >}} | {{< icon "wip" >}} | {{< icon "check-green" >}} | - | - |
 | [BlindBit Desktop](https://github.com/setavenger/blindbit-desktop/releases) | [setavenger/blindbit-desktop](https://github.com/setavenger/blindbit-desktop/) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | - |
-| [BlueWallet](https://bluewallet.io/) | [bluewallet/bluewallet](https://github.com/bluewallet/bluewallet) | {{< icon "check-green" >}} | {{< icon "wip" >}} | - | - | - |
 | [Cake Wallet](https://cakewallet.com) | [cake-tech/cake_wallet](https://github.com/cake-tech/cake_wallet) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | - |
 | [Dana Wallet](https://danawallet.app) | [cygnet3/dana](https://github.com/cygnet3/dana) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | - |
-| [Nunchuk Wallet](https://nunchuk.io) | [nunchuk-io](https://github.com/nunchuk-io) | {{< icon "check-green" >}} | {{< icon "x-red" >}} | - | - | - |
-| [Silentium](https://app.silentium.dev) [^2] | [louisinger/silentium](https://github.com/louisinger/silentium) | {{< icon "check-green" >}} | {{< icon "warning" >}} | - | - | - |
 | [Sparrow Wallet](https://sparrowwallet.com/) | [sparrowwallet/sparrow](https://github.com/sparrowwallet/sparrow) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | {{< icon "check-green" >}} | {{< icon "check-green" >}} |
-| [Unchained](https://www.unchained.com/) | [caravan-bitcoin/caravan](https://github.com/caravan-bitcoin/caravan/pull/496) | {{< icon "wip" >}} | {{< icon "x-red" >}} | - | {{< icon "wip" >}} | - |
+
+### Send-only
+
+| Wallet | Source | Sending | Receiving | Privacy-preserving scanning | BIP375 | BIP376 |
+| ------ | ------ | :-----: | :-------: | :-----------------------------: | :--------: | :--------: |
+| [BitBox](https://bitbox.swiss/) | [BitBoxSwiss/bitbox-wallet-app](https://github.com/BitBoxSwiss/bitbox-wallet-app) | {{< icon "check-green" >}} | {{< icon "x-red" >}} | - | - | - |
+| [BlueWallet](https://bluewallet.io/) | [bluewallet/bluewallet](https://github.com/bluewallet/bluewallet) | {{< icon "check-green" >}} | {{< icon "wip" >}} | - | - | - |
+| [Nunchuk Wallet](https://nunchuk.io) | [nunchuk-io](https://github.com/nunchuk-io) | {{< icon "check-green" >}} | {{< icon "x-red" >}} | - | - | - |
 | [Wasabi Wallet](https://wasabiwallet.io/) | [WalletWasabi/WalletWasabi](https://github.com/WalletWasabi/WalletWasabi) | {{< icon "check-green" >}} | {{< icon "x-red" >}} | - | - | - |
 
-## Hardware wallets
+### In progress
 
-| Wallet | Github | Sending | BIP375 | BIP376 |
+| Wallet | Source | Sending | Receiving | Privacy-preserving scanning | BIP375 | BIP376 |
+| ------ | ------ | :-----: | :-------: | :-----------------------------: | :--------: | :--------: |
+| [Bitcoin Core](https://bitcoin.org/en/bitcoin-core/) | [bitcoin/bitcoin](https://github.com/bitcoin/bitcoin/pull/32966) | {{< icon "wip" >}} | {{< icon "wip" >}} | {{< icon "check-green" >}} | - | - |
+| [Unchained](https://www.unchained.com/) | [caravan-bitcoin/caravan](https://github.com/caravan-bitcoin/caravan/pull/496) | {{< icon "wip" >}} | {{< icon "x-red" >}} | - | {{< icon "wip" >}} | - |
+
+## Hardware signers
+
+Signing devices for Silent Payment transactions (BIP375 to send, BIP376 to spend). They don't scan or hold funds themselves, so pair them with a software wallet above.
+
+| Wallet | Source | Sending | BIP375 | BIP376 |
 | ------ | ------ | :-----: | :----: | :----: |
 | [BitBox02](https://bitbox.swiss/) | [BitBoxSwiss/bitbox02-firmware](https://github.com/BitBoxSwiss/bitbox02-firmware) | {{< icon "check-green" >}} | {{< icon "x-red" >}} | {{< icon "x-red" >}} |
 | [Coldcard](https://coldcard.com/) | [Coldcard/firmware](https://github.com/Coldcard/firmware) | {{< icon "wip" >}} | {{< icon "wip" >}} | {{< icon "wip" >}} |
 | [SeedSigner](https://seedsigner.com/) | [SeedSigner/seedsigner](https://github.com/SeedSigner/seedsigner) | {{< icon "wip" >}} | {{< icon "x-red" >}} | {{< icon "x-red" >}} |
+
+## Applications
+
+Applications that use Silent Payments for a specific purpose, with a built-in wallet.
+
+| Wallet | Source | Sending | Receiving | Privacy-preserving scanning | BIP375 | BIP376 |
+| ------ | ------ | :-----: | :-------: | :-----------------------------: | :--------: | :--------: |
+| [Agora](https://agora.spot) | [soapbox-pub/agora](https://gitlab.com/soapbox-pub/agora) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | - |
+
+## Experimental & proof-of-concept
+
+Early proof-of-concept projects. Try with caution, not with meaningful funds.
+
+| Wallet | Source | Sending | Receiving | Privacy-preserving scanning | BIP375 | BIP376 |
+| ------ | ------ | :-----: | :-------: | :-----------------------------: | :--------: | :--------: |
+| [Silentium](https://app.silentium.dev)[^2] | [louisinger/silentium](https://github.com/louisinger/silentium) | {{< icon "check-green" >}} | {{< icon "warning" >}} | - | - | - |
 
 [^1]: "Privacy preserving scanning" here denotes an architecture where no output information is revealed to the back-end server. While this is the only possible back-end approach for now, it's very likely we will see future approaches that give the view key over to a back-end server to allow background sync, while sacrificing privacy of Silent Payments outputs to that third-party server. This field is a way that we can denote that in the future as-necessary.
 [^2]: Silentium is a proof-of-concept and should be used with caution! From the developer:

--- a/content/docs/wallets.md
+++ b/content/docs/wallets.md
@@ -59,7 +59,7 @@ Applications that use Silent Payments for a specific purpose, with a built-in wa
 
 | Wallet | Source | Sending | Receiving | Privacy-preserving scanning | BIP375 | BIP376 |
 | ------ | ------ | :-----: | :-------: | :-----------------------------: | :--------: | :--------: |
-| [Agora](https://agora.spot) | [soapbox-pub/agora](https://gitlab.com/soapbox-pub/agora) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | - |
+| [Agora](https://agora.spot)[^5] | [soapbox-pub/agora](https://gitlab.com/soapbox-pub/agora) | {{< icon "check-green" >}} | {{< icon "check-green" >}} | {{< icon "check-green" >}} | - | - |
 
 ## Experimental & proof-of-concept
 
@@ -74,3 +74,4 @@ Early proof-of-concept projects. Try with caution, not with meaningful funds.
     > This is an experimental project acting as a proof of concept for Silent Payments light wallets. Use at your own risk.
 [^3]: [BIP375](https://github.com/bitcoin/bips/blob/master/bip-0375.mediawiki) — Sending Silent Payments with PSBT. Defines the PSBT fields required for a hardware signer to participate in constructing a transaction that sends to a Silent Payment address.
 [^4]: [BIP376](https://github.com/bitcoin/bips/blob/master/bip-0376.mediawiki) — Spending Silent Payments with PSBT. Defines the PSBT fields required for a hardware signer to spend a previously received Silent Payment output.
+[^5]: Agora is a Bitcoin donation/crowdfunding platform with a built-in wallet. It runs as a browser-based hot wallet tied to your Nostr key (nsec). For anything beyond small amounts, transfer the funds to another wallet with a different seed for secure storage.


### PR DESCRIPTION
I was reviewing the recent PRs like #46 and #47 while making a few other updates.  

This update proposes new categories to address the growing list of wallets:
- Wallets
- Hardware signers
- Applications _(is there a better name for this category?)_
- Experimental & POC

I will leave this as a draft so that @derekross can review the Agora footnote in 52f2059.  I wanted to stress the distinction that long-term wallets require new entropy (nsec -> HD wallet seed). If you prefer I raise this point as [agora.spot](https://gitlab.com/soapbox-pub/agora) issue let me know.

