### PR TITLE
Warn against reusing generated Taproot addresses

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -7,7 +7,7 @@ summary: Silent Payments allow you to create a single, static address to share w
 Silent Payments allow you to create a single, static address to share with friends, use for donations, or post for tips *without sacrificing privacy*. When someone wants to send you a payment, they use the unique public key that is a part of your Silent Payment address, combine it with the public keys of the outputs they want to send and generate a unique, one-time address that looks on-chain just like any other Taproot address. The main advantages of Silent Payments are:
 
 - {{< icon "check" >}} Simpler user experience: users just need to worry about a single, static address instead of the hurdles of generating new addresses for every receive.
-- {{< icon "check" >}} Better receiver privacy: address re-use with Silent Payments is impossible, as no two senders can generate the same on-chain address.
+- {{< icon "check" >}} Better receiver privacy: payments made to a Silent Payment address avoid on-chain address reuse, as senders derive fresh Taproot outputs.
 - {{< icon "check" >}} Better sender privacy: receivers have no way of connecting sends from the same receiver together, providing better privacy for even the sender.
 - {{< icon "check" >}} No server required: anyone with a wallet supporting Silent Payments can receive funds without address reuse, without communication, and without running complex infrastructure.
 

--- a/content/docs/explained.md
+++ b/content/docs/explained.md
@@ -24,6 +24,10 @@ What a Silent Payment address looks like on-chain (i.e. any Taproot address):
 
 `bc1pftjlgdq0ufhq7qwd0atxhrjhlnpmc8v4x50tgytygzk5rz339u6qngunq4`
 
+{{< callout type="warning" >}}
+  Do not reuse or share the generated on-chain Taproot address (`bc1p...`) as a receive address. Only the Silent Payment address (`sp1...`) is reusable. Funds sent directly to a generated Taproot address may not be detected by Silent Payment wallet scanning.
+{{< /callout >}}
+
 {{< callout type="info" >}}
   Note that the addresses above are real-world examples, with the Taproot address actually being used in a payment to the above Silent Payment address.
 


### PR DESCRIPTION
### What this PR will do:

- Clarifies that the reusable address in Silent Payments is the `sp1...` address, not the generated on-chain `bc1p...` Taproot output address.

- This helps warn users that funds sent directly to a generated Taproot address may not be detected by Silent Payment wallet scanning.