### PR TITLE
Fix archetype default.md to use YAML frontmatter

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,5 +1,5 @@
-+++
-title = '{{ replace .File.ContentBaseName "-" " " | title }}'
-date = {{ .Date }}
-draft = true
-+++
+---
+title: "{{ replace .File.ContentBaseName "-" " " | title }}"
+date: {{ .Date }}
+draft: true
+---


### PR DESCRIPTION
### Changes

- **archetypes/default.md**: Changed from TOML (`+++`) to YAML (`---`) frontmatter to match all existing content files in the repo

See discussion in #homelab for full audit.