### PR TITLE
Add Hugo cache, docker sha tag, and HEALTHCHECK

### DIFF
--- a/.github/workflows/build-site-and-push-image.yml
+++ b/.github/workflows/build-site-and-push-image.yml
@@ -33,9 +33,16 @@ jobs:
           hugo-version: 'latest'
           extended: true
 
+      - name: Cache Hugo resources
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/hugo_cache
+          key: hugo-cache-${{ hashFiles('hugo.yaml') }}
+          restore-keys: |
+            hugo-cache-
+
       - name: Build site
         run: hugo --destination ./public
-
 
       - name: Install zopfli
         run: sudo apt-get install -y --no-install-recommends zopfli
@@ -58,6 +65,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/silentpaymentsxyz:latest
+            ghcr.io/${{ github.repository_owner }}/silentpaymentsxyz:${{ github.sha }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -36,6 +36,14 @@ jobs:
           hugo-version: 'latest'
           extended: true
 
+      - name: Cache Hugo resources
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/hugo_cache
+          key: hugo-cache-${{ hashFiles('hugo.yaml') }}
+          restore-keys: |
+            hugo-cache-
+
       - name: Build site with preview baseURL
         run: |
           hugo \

--- a/.github/workflows/test-site-build.yml
+++ b/.github/workflows/test-site-build.yml
@@ -31,6 +31,14 @@ jobs:
           hugo-version: 'latest'
           extended: true
 
+      - name: Cache Hugo resources
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/hugo_cache
+          key: hugo-cache-${{ hashFiles('hugo.yaml') }}
+          restore-keys: |
+            hugo-cache-
+
       - name: Build site
         run: hugo --destination ./public
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ RUN rm /etc/nginx/conf.d/default.conf
 # Copy custom nginx.conf file
 COPY nginx.conf /etc/nginx/nginx.conf
 
+HEALTHCHECK CMD wget -qO- http://localhost:80 || exit 1
+
 EXPOSE 80


### PR DESCRIPTION
### Changes

- **Hugo cache**: Added `@actions/cache@v4` step in all three CI workflows (build+push, test, preview) for `/home/runner/.cache/hugo_cache` keyed on config hash. Speeds up repeated builds.
- **Docker sha tag**: Added `${{ github.sha }}` as a secondary image tag alongside `:latest` for rollback safety.
- **HEALTHCHECK**: Added `HEALTHCHECK CMD wget -qO- http://localhost:80 || exit 1` to Dockerfile.